### PR TITLE
me after changing the whole ass framework the project is running on:

### DIFF
--- a/KerbalScreenshots/KerbalScreenshots.sln
+++ b/KerbalScreenshots/KerbalScreenshots.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.36109.1 d17.14
+VisualStudioVersion = 17.14.36121.58 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KerbalScreenshots", "KerbalScreenshots\KerbalScreenshots.csproj", "{FA732903-6A2B-4777-978E-F7594500AEED}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KerbalScreenshots", "KerbalScreenshots\KerbalScreenshots.csproj", "{73D982E6-5FFD-47A7-AFBF-D79E70B698E9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,15 +11,15 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FA732903-6A2B-4777-978E-F7594500AEED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FA732903-6A2B-4777-978E-F7594500AEED}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FA732903-6A2B-4777-978E-F7594500AEED}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FA732903-6A2B-4777-978E-F7594500AEED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73D982E6-5FFD-47A7-AFBF-D79E70B698E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73D982E6-5FFD-47A7-AFBF-D79E70B698E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73D982E6-5FFD-47A7-AFBF-D79E70B698E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73D982E6-5FFD-47A7-AFBF-D79E70B698E9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {D050A3D7-D77E-429A-8384-22FF54ADC168}
+		SolutionGuid = {4ECA2BA0-732B-4713-A876-D0A8EAF148B0}
 	EndGlobalSection
 EndGlobal

--- a/KerbalScreenshots/KerbalScreenshots/Class1.cs
+++ b/KerbalScreenshots/KerbalScreenshots/Class1.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace KerbalScreenshots
 {
@@ -7,11 +7,17 @@ namespace KerbalScreenshots
     {
 
         public KeyCode screenshot = KeyCode.F2;
+
         private void Update()
         {
+            string filePath = "GameData\\KerbalScreenshots\\LoadingScreens\\";
+            string fileName = "test";
+
             if (Input.GetKeyDown(screenshot))
             {
-                Debug.Log("KERBAL SCREENSHOTS WORKS!!! yay");
+                string finalFile = filePath + fileName + ".png";
+                //ScreenCapture.CaptureScreenshot(finalFile);
+                Debug.Log("Screenshot Taken at " + finalFile);
             }
         }
     }

--- a/KerbalScreenshots/KerbalScreenshots/KerbalScreenshots.csproj
+++ b/KerbalScreenshots/KerbalScreenshots/KerbalScreenshots.csproj
@@ -1,11 +1,35 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{73D982E6-5FFD-47A7-AFBF-D79E70B698E9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>KerbalScreenshots</RootNamespace>
+    <AssemblyName>KerbalScreenshots</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\..\..\..\Program Files\Epic Games\KerbalSpaceProgram\English\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
@@ -13,6 +37,7 @@
     <Reference Include="Assembly-CSharp-firstpass">
       <HintPath>..\..\..\..\..\..\..\Program Files\Epic Games\KerbalSpaceProgram\English\KSP_x64_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\..\..\Program Files\Epic Games\KerbalSpaceProgram\English\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
@@ -22,9 +47,16 @@
     <Reference Include="UnityEngine.InputLegacyModule">
       <HintPath>..\..\..\..\..\..\..\Program Files\Epic Games\KerbalSpaceProgram\English\KSP_x64_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.ScreenCaptureModule">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Epic Games\KerbalSpaceProgram\English\KSP_x64_Data\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>..\..\..\..\..\..\..\Program Files\Epic Games\KerbalSpaceProgram\English\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
-
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/KerbalScreenshots/KerbalScreenshots/KerbalScreenshotsCore.cs
+++ b/KerbalScreenshots/KerbalScreenshots/KerbalScreenshotsCore.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace KerbalScreenshots
 {
-    [KSPAddon(KSPAddon.Startup.AllGameScenes, true)]
+    [KSPAddon(KSPAddon.Startup.AllGameScenes, false)]
     public class KerbalScreenshotsCore : MonoBehaviour
     {
 

--- a/KerbalScreenshots/KerbalScreenshots/Properties/AssemblyInfo.cs
+++ b/KerbalScreenshots/KerbalScreenshots/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("KerbalScreenshots")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("KerbalScreenshots")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("73d982e6-5ffd-47a7-afbf-d79e70b698e9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
here's what i went through to try and get visual studio to let me use an older version of .net:
-go into the .csproj file
-"install" .NET 4.7.2
-change targeted framework to `net472`
-visual studio doesn't like it
-google
-delete the nullable whatever line under it & restart VS
-VS shits its pants
-try and repeat with .NET 4.5 with a new project
-.NET 4.5 can't install
-ignore
-deja vu
-try and use .NET 4.8 bc it comes prebundled with windows apparently
-deju 2
-try and make new project with .NET 4.8
-not appearing as an option??? (still don't know why)
-google
-notice that googles AI summary is saying something about `Class Library (.NET Framework)`
-try that bc .NET framework 4.7.2 is, well, a framework
-copy+paste code
-_it works_
;v;
theres a lesson here somewhere